### PR TITLE
Graph based conversion

### DIFF
--- a/src/tech/datatype/base.cljc
+++ b/src/tech/datatype/base.cljc
@@ -162,11 +162,6 @@ Contains:
     dest))
 
 
-(extend-type Object
-  PCopyQuery
-  (get-copy-fn [dest dest-offset] #(generic-copy! %1 %2 dest dest-offset %3)))
-
-
 (defprotocol PView
   (->view-impl [item offset elem-count]))
 

--- a/src/tech/datatype/core.clj
+++ b/src/tech/datatype/core.clj
@@ -148,9 +148,6 @@ this involves a double-dispatch on both the src and dest arguments:
 (extend-type ByteArrayView
   base/PDatatype
   (get-datatype [item] :byte)
-  base/PCopyQuery
-  (get-copy-fn [dest dest-offset]
-    (marshal/get-copy-to-fn (.data dest) (+ (long dest-offset) (.offset dest))))
   base/PAccess
   (set-value! [item in-offset value] (aset (.data item) (+ (long in-offset)
                                                            (.offset item)) (byte value)))
@@ -168,9 +165,6 @@ this involves a double-dispatch on both the src and dest arguments:
 (extend-type ShortArrayView
   base/PDatatype
   (get-datatype [item] :short)
-  base/PCopyQuery
-  (get-copy-fn [dest dest-offset]
-    (marshal/get-copy-to-fn (.data dest) (+ (long dest-offset) (.offset dest))))
   base/PAccess
   (set-value! [item in-offset value] (aset (.data item) (+ (long in-offset) (.offset item))
                                            (short value)))
@@ -188,9 +182,6 @@ this involves a double-dispatch on both the src and dest arguments:
 (extend-type IntArrayView
   base/PDatatype
   (get-datatype [item] :int)
-  base/PCopyQuery
-  (get-copy-fn [dest dest-offset]
-    (marshal/get-copy-to-fn (.data dest) (+ (long dest-offset) (.offset dest))))
   base/PAccess
   (set-value! [item in-offset value] (aset (.data item) (+ (long in-offset) (.offset item))
                                            (int value)))
@@ -207,9 +198,6 @@ this involves a double-dispatch on both the src and dest arguments:
 (extend-type LongArrayView
   base/PDatatype
   (get-datatype [item] :long)
-  base/PCopyQuery
-  (get-copy-fn [dest dest-offset]
-    (marshal/get-copy-to-fn (.data dest) (+ (long dest-offset) (.offset dest))))
   base/PAccess
   (set-value! [item in-offset value] (aset (.data item) (+ (long in-offset) (.offset item))
                                            (long value)))
@@ -226,9 +214,6 @@ this involves a double-dispatch on both the src and dest arguments:
 (extend-type FloatArrayView
   base/PDatatype
   (get-datatype [item] :float)
-  base/PCopyQuery
-  (get-copy-fn [dest dest-offset]
-    (marshal/get-copy-to-fn (.data dest) (+ (long dest-offset) (.offset dest))))
   base/PAccess
   (set-value! [item in-offset value] (aset (.data item) (+ (long in-offset) (.offset item))
                                            (float value)))
@@ -245,9 +230,6 @@ this involves a double-dispatch on both the src and dest arguments:
 (extend-type DoubleArrayView
   base/PDatatype
   (get-datatype [item] :double)
-  base/PCopyQuery
-  (get-copy-fn [dest dest-offset]
-    (marshal/get-copy-to-fn (.data dest) (+ (long dest-offset) (.offset dest))))
   base/PAccess
   (set-value! [item in-offset value] (aset (.data item) (+ (long in-offset) (.offset item))
                                            (double value)))
@@ -282,9 +264,6 @@ this involves a double-dispatch on both the src and dest arguments:
 (extend-type (Class/forName "[B")
   base/PDatatype
   (get-datatype [item] :byte)
-  base/PCopyQuery
-  (get-copy-fn [dest dest-offset]
-    (marshal/get-copy-to-fn dest dest-offset))
   base/PAccess
   (set-value! [item ^long offset value] (aset ^bytes item offset (byte value)))
   (set-constant! [item ^long offset value ^long elem-count]
@@ -300,9 +279,6 @@ this involves a double-dispatch on both the src and dest arguments:
 (extend-type (Class/forName "[S")
   base/PDatatype
   (get-datatype [item] :short)
-  base/PCopyQuery
-  (get-copy-fn [dest dest-offset]
-    (marshal/get-copy-to-fn dest dest-offset))
   base/PAccess
   (set-value! [item ^long offset value] (aset ^shorts item offset (short value)))
   (set-constant! [item ^long offset value ^long elem-count]
@@ -318,9 +294,6 @@ this involves a double-dispatch on both the src and dest arguments:
 (extend-type (Class/forName "[I")
   base/PDatatype
   (get-datatype [item] :int)
-  base/PCopyQuery
-  (get-copy-fn [dest dest-offset]
-    (marshal/get-copy-to-fn dest dest-offset))
   base/PAccess
   (set-value! [item ^long offset value] (aset ^ints item offset (int value)))
   (set-constant! [item ^long offset value ^long elem-count]
@@ -336,9 +309,6 @@ this involves a double-dispatch on both the src and dest arguments:
 (extend-type (Class/forName "[J")
   base/PDatatype
   (get-datatype [item] :long)
-  base/PCopyQuery
-  (get-copy-fn [dest dest-offset]
-    (marshal/get-copy-to-fn dest dest-offset))
   base/PAccess
   (set-value! [item ^long offset value] (aset ^longs item offset (long value)))
   (set-constant! [item ^long offset value ^long elem-count]
@@ -354,9 +324,6 @@ this involves a double-dispatch on both the src and dest arguments:
 (extend-type (Class/forName "[F")
   base/PDatatype
   (get-datatype [item] :float)
-  base/PCopyQuery
-  (get-copy-fn [dest dest-offset]
-    (marshal/get-copy-to-fn dest dest-offset))
   base/PAccess
   (set-value! [item ^long offset value] (aset ^floats item offset (float value)))
   (set-constant! [item ^long offset value ^long elem-count]
@@ -372,9 +339,6 @@ this involves a double-dispatch on both the src and dest arguments:
 (extend-type (Class/forName "[D")
   base/PDatatype
   (get-datatype [item] :double)
-  base/PCopyQuery
-  (get-copy-fn [dest dest-offset]
-    (marshal/get-copy-to-fn dest dest-offset))
   base/PAccess
   (set-value! [item ^long offset value] (aset ^doubles item offset (double value)))
   (set-constant! [item ^long offset value ^long elem-count]
@@ -425,9 +389,6 @@ this involves a double-dispatch on both the src and dest arguments:
 
 
 (extend-type Buffer
-  base/PCopyQuery
-  (get-copy-fn [dest dest-offset]
-    (marshal/get-copy-to-fn dest dest-offset))
   mp/PElementCount
   (element-count [item] (.remaining item))
   base/PCopyRawData
@@ -529,20 +490,6 @@ this involves a double-dispatch on both the src and dest arguments:
                                  (mp/to-double-array raw-data))]
       (copy-raw->item! item-data ary-target target-offset))))
 
-
-;;Add the overloads for object for marshal-type copies.
-(defmacro generic-copy-impl
-  [dest-type cast-type-fn copy-to-dest-fn cast-fn]
-  `[(keyword (name ~copy-to-dest-fn)) base/generic-copy!])
-
-
-(extend Object
-  marshal/PCopyToArray
-  (->> (marshal/array-type-iterator generic-copy-impl)
-       (into {}))
-  marshal/PCopyToBuffer
-  (->> (marshal/buffer-type-iterator generic-copy-impl)
-       (into {})))
 
 (extend-type Object
   base/PCopyRawData

--- a/src/tech/datatype/marshal.clj
+++ b/src/tech/datatype/marshal.clj
@@ -6,11 +6,55 @@
             FloatBuffer DoubleBuffer Buffer]
            [tech.datatype DoubleArrayView FloatArrayView
             LongArrayView IntArrayView ShortArrayView ByteArrayView
-            ArrayView]))
+            ArrayView ArrayViewBase]))
 
 ;;Some utility items to make the macros easier.
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
+
+
+(defprotocol PContainerType
+  (get-container-type [item]))
+
+(extend-type ArrayViewBase
+  PContainerType
+  (get-container-type [item] :array-view))
+
+(extend-type Buffer
+  PContainerType
+  (get-container-type [item] :nio-buffer))
+
+(extend-type (Class/forName "[B")
+  PContainerType
+  (get-container-type [item] :java-array))
+
+(extend-type (Class/forName "[S")
+  PContainerType
+  (get-container-type [item] :java-array))
+
+(extend-type (Class/forName "[I")
+  PContainerType
+  (get-container-type [item] :java-array))
+
+(extend-type (Class/forName "[J")
+  PContainerType
+  (get-container-type [item] :java-array))
+
+(extend-type (Class/forName "[F")
+  PContainerType
+  (get-container-type [item] :java-array))
+
+(extend-type (Class/forName "[D")
+  PContainerType
+  (get-container-type [item] :java-array))
+
+
+
+;;Conversion is src-container< type>, offset -> dst-container<type>, offset
+(def ^:dynamic conversion-table (atom {}))
+
+;;Copy is src-container<type>, offset, dst-container<type>, offset, num-elems -> nil
+(def ^:dynamic copy-table (atom {}))
 
 
 (defprotocol PCopyToArray

--- a/src/tech/datatype/marshal.clj
+++ b/src/tech/datatype/marshal.clj
@@ -1,7 +1,9 @@
 (ns tech.datatype.marshal
   "Namespace to contain the madness that happens when you want to marshal
   an (nio buffer or array) or one type to a (nio buffer or array) or another type."
-  (:require [clojure.core.matrix.macros :refer [c-for]])
+  (:require [clojure.core.matrix.macros :refer [c-for]]
+            [tech.datatype.base :as base]
+            [clojure.set :as cset])
   (:import [java.nio ByteBuffer ShortBuffer IntBuffer LongBuffer
             FloatBuffer DoubleBuffer Buffer]
            [tech.datatype DoubleArrayView FloatArrayView
@@ -14,71 +16,71 @@
 
 
 (defprotocol PContainerType
-  (get-container-type [item]))
+  (container-type [item]))
 
 (extend-type ArrayViewBase
   PContainerType
-  (get-container-type [item] :array-view))
+  (container-type [item] :array-view))
 
 (extend-type Buffer
   PContainerType
-  (get-container-type [item] :nio-buffer))
+  (container-type [item] :nio-buffer))
 
 (extend-type (Class/forName "[B")
   PContainerType
-  (get-container-type [item] :java-array))
+  (container-type [item] :java-array))
 
 (extend-type (Class/forName "[S")
   PContainerType
-  (get-container-type [item] :java-array))
+  (container-type [item] :java-array))
 
 (extend-type (Class/forName "[I")
   PContainerType
-  (get-container-type [item] :java-array))
+  (container-type [item] :java-array))
 
 (extend-type (Class/forName "[J")
   PContainerType
-  (get-container-type [item] :java-array))
+  (container-type [item] :java-array))
 
 (extend-type (Class/forName "[F")
   PContainerType
-  (get-container-type [item] :java-array))
+  (container-type [item] :java-array))
 
 (extend-type (Class/forName "[D")
   PContainerType
-  (get-container-type [item] :java-array))
-
+  (container-type [item] :java-array))
 
 
 ;;Conversion is src-container< type>, offset -> dst-container<type>, offset
-(def ^:dynamic conversion-table (atom {}))
-
-;;Copy is src-container<type>, offset, dst-container<type>, offset, num-elems -> nil
-(def ^:dynamic copy-table (atom {}))
-
-
-(defprotocol PCopyToArray
-  (copy-to-byte-array [src src-offset dest dest-offset n-elems])
-  (copy-to-short-array [src src-offset dest dest-offset n-elems])
-  (copy-to-int-array [src src-offset dest dest-offset n-elems])
-  (copy-to-long-array [src src-offset dest dest-offset n-elems])
-  (copy-to-float-array [src src-offset dest dest-offset n-elems])
-  (copy-to-double-array [src src-offset dest dest-offset n-elems]))
-
-
-(defprotocol PCopyToBuffer
-  (copy-to-byte-buffer [src src-offset dest dest-offset n-elems])
-  (copy-to-short-buffer [src src-offset dest dest-offset n-elems])
-  (copy-to-int-buffer [src src-offset dest dest-offset n-elems])
-  (copy-to-long-buffer [src src-offset dest dest-offset n-elems])
-  (copy-to-float-buffer [src src-offset dest dest-offset n-elems])
-  (copy-to-double-buffer [src src-offset dest dest-offset n-elems]))
+;;Conversion map is a double-lookup of src-type to a map of dst-type to a function
+;;that converts src type to dst type.
+(def ^:dynamic conversion-table (atom {:array-view
+                                       {:java-array
+                                        (fn [src-item src-offset]
+                                          (let [src-dtype (base/get-datatype src-item)
+                                                src-offset (long src-offset)
+                                                src-item ^ArrayViewBase src-item
+                                                view-offset (.offset src-item)
+                                                dst-item (condp = src-dtype
+                                                           :byte (.data ^ByteArrayView src-item)
+                                                           :short (.data ^ShortArrayView src-item)
+                                                           :int (.data ^IntArrayView src-item)
+                                                           :long (.data ^LongArrayView src-item)
+                                                           :float (.data ^FloatArrayView src-item)
+                                                           :double (.data ^DoubleArrayView src-item))]
+                                            [dst-item (+ src-offset view-offset)]))}}))
 
 
-(defprotocol PTypeToCopyToFn
-  "Given two arguments, [dest dest-offset] return a function taking signature
-[src src-offset] that efficiently implements the copy operation."
-  (get-copy-to-fn [dest dest-offset]))
+(defn identity-conversion
+  [src-item src-offset]
+  [src-item src-offset])
+
+
+(defn add-conversion-fn
+  [src-container-type dst-container-type convert-fn]
+  (swap! conversion-table
+         (fn [convert-map]
+           (assoc-in convert-map [:src-container-type :dst-container-type] convert-fn))))
 
 
 (defn as-byte-buffer
@@ -99,17 +101,6 @@
 (defn as-double-buffer
   ^DoubleBuffer [obj] obj)
 
-
-(defmacro buffer-type-iterator
-  [inner-macro & args]
-  `[(~inner-macro ByteBuffer as-byte-buffer 'copy-to-byte-buffer byte ~@args)
-    (~inner-macro ShortBuffer as-short-buffer 'copy-to-short-buffer short ~@args)
-    (~inner-macro IntBuffer as-int-buffer 'copy-to-int-buffer int ~@args)
-    (~inner-macro LongBuffer as-long-buffer 'copy-to-long-buffer long ~@args)
-    (~inner-macro FloatBuffer as-float-buffer 'copy-to-float-buffer float ~@args)
-    (~inner-macro DoubleBuffer as-double-buffer 'copy-to-double-buffer double ~@args)])
-
-
 (defn as-byte-array
   ^bytes [obj] obj)
 
@@ -128,17 +119,67 @@
 (defn as-double-array
   ^doubles [obj] obj)
 
+(defn as-byte-array-view
+  ^ByteArrayView [obj] obj)
 
-(defmacro array-type-iterator
-  [inner-macro & args]
-  `[(~inner-macro (Class/forName "[B") as-byte-array 'copy-to-byte-array byte ~@args)
-    (~inner-macro (Class/forName "[S") as-short-array 'copy-to-short-array short ~@args)
-    (~inner-macro (Class/forName "[I") as-int-array 'copy-to-int-array int ~@args)
-    (~inner-macro (Class/forName "[J") as-long-array 'copy-to-long-array long ~@args)
-    (~inner-macro (Class/forName "[F") as-float-array 'copy-to-float-array float ~@args)
-    (~inner-macro (Class/forName "[D") as-double-array 'copy-to-double-array double ~@args)])
+(defn as-short-array-view
+  ^ShortArrayView [obj] obj)
+
+(defn as-int-array-view
+  ^IntArrayView [obj] obj)
+
+(defn as-long-array-view
+  ^LongArrayView [obj] obj)
+
+(defn as-float-array-view
+  ^FloatArrayView [obj] obj)
+
+(defn as-double-array-view
+  ^DoubleArrayView [obj] obj)
 
 
+(defmacro datatype->array-cast-fn
+  [dtype buf]
+  (condp = dtype
+    :byte `(as-byte-array ~buf)
+    :short `(as-short-array ~buf)
+    :int `(as-int-array ~buf)
+    :long `(as-long-array ~buf)
+    :float `(as-float-array ~buf)
+    :double `(as-double-array ~buf)))
+
+
+(defmacro datatype->view-cast-fn
+  [dtype buf]
+  (condp = dtype
+    :byte `(as-byte-array-view ~buf)
+    :short `(as-short-array-view ~buf)
+    :int `(as-int-array-view ~buf)
+    :long `(as-long-array-view ~buf)
+    :float `(as-float-array-view ~buf)
+    :double `(as-double-array-view ~buf)))
+
+
+(defmacro datatype->buffer-cast-fn
+  [dtype buf]
+  (condp = dtype
+    :byte `(as-byte-buffer ~buf)
+    :short `(as-short-buffer ~buf)
+    :int `(as-int-buffer ~buf)
+    :long `(as-long-buffer ~buf)
+    :float `(as-float-buffer ~buf)
+    :double `(as-double-buffer ~buf)))
+
+
+(defmacro datatype->cast-fn
+  [dtype val]
+  (condp = dtype
+    :byte `(byte ~val)
+    :short `(short ~val)
+    :int `(int ~val)
+    :long `(long ~val)
+    :float `(float ~val)
+    :double `(double ~val)))
 
 (defmacro create-buffer->array-fn
   "Create a function that assumes the types do not match
@@ -195,126 +236,141 @@ and thus needs to cast."
                     (~dest-cast-fn (.get src# (+ src-offset# idx#))))))))
 
 
-(defmacro array->array-copy-iter
-  [dest-type dest-type-fn copy-to-dest-fn dest-cast-fn src-cast-fn]
-  `[(keyword (name ~copy-to-dest-fn)) (create-array->array-fn ~src-cast-fn ~dest-type-fn ~dest-cast-fn)])
+;;Copy is src-container<type>, offset, dst-container<type>, offset, num-elems -> nil
+(def ^:dynamic copy-table (atom {}))
+
+(def datatype-pairs
+  (->> (for [src-dtype base/datatypes
+             dst-dtype base/datatypes]
+         [src-dtype dst-dtype])
+       vec))
+
+(defn add-copy-operation
+  "Add a new copy operation; the operation map must contain all n^2 datatype copy ops."
+  [src-container-type dst-container-type copy-operation-map]
+  (when-not (= (set (keys copy-operation-map))
+               (set datatype-pairs))
+    (throw (ex-info "Not all datatype combinations are present in the copy operation map"
+                    {:missing (cset/difference (set datatype-pairs)
+                                               (set (keys copy-operation-map)))})))
+  (swap! copy-table assoc [src-container-type dst-container-type] copy-operation-map))
 
 
-(defmacro array->buffer-copy-iter
-  [dest-type dest-type-fn copy-to-dest-fn dest-cast-fn src-cast-fn]
-  `[(keyword (name ~copy-to-dest-fn)) (create-array->buffer-fn ~src-cast-fn ~dest-type-fn ~dest-cast-fn)])
+(defmacro build-core-copy-operations
+  []
+  {[:java-array :java-array]
+   (->> datatype-pairs
+        (map (fn [[src-dtype dst-dtype]]
+               [[src-dtype dst-dtype]
+                `(fn [src# src-offset# dst# dst-offset# n-elems#]
+                   (let [src# (datatype->array-cast-fn ~src-dtype src#)
+                         dst# (datatype->array-cast-fn ~dst-dtype dst#)
+                         src-offset# (long src-offset#)
+                         dst-offset# (long dst-offset#)
+                         n-elems# (long n-elems#)]
+                     (c-for [idx# 0 (< idx# n-elems#) (inc idx#)]
+                            (aset dst# (+ idx# dst-offset#)
+                                  (datatype->cast-fn
+                                   ~dst-dtype
+                                   (aget src# (+ idx# src-offset#)))))))]))
+        (into {}))
+   [:java-array :nio-buffer]
+   (->> datatype-pairs
+        (map (fn [[src-dtype dst-dtype]]
+               [[src-dtype dst-dtype]
+                `(fn [src# src-offset# dst# dst-offset# n-elems#]
+                   (let [src# (datatype->array-cast-fn ~src-dtype src#)
+                         dst# (datatype->buffer-cast-fn ~dst-dtype dst#)
+                         src-offset# (long src-offset#)
+                         dst-offset# (long dst-offset#)
+                         n-elems# (long n-elems#)]
+                     (c-for [idx# 0 (< idx# n-elems#) (inc idx#)]
+                            (.put dst# (+ idx# dst-offset#)
+                                  (datatype->cast-fn
+                                   ~dst-dtype
+                                   (aget src# (+ idx# src-offset#)))))))]))
+        (into {}))
+   [:nio-buffer :java-array]
+   (->> datatype-pairs
+        (map (fn [[src-dtype dst-dtype]]
+               [[src-dtype dst-dtype]
+                `(fn [src# src-offset# dst# dst-offset# n-elems#]
+                   (let [src# (datatype->buffer-cast-fn ~src-dtype src#)
+                         dst# (datatype->array-cast-fn ~dst-dtype dst#)
+                         src-offset# (long src-offset#)
+                         dst-offset# (long dst-offset#)
+                         n-elems# (long n-elems#)]
+                     (c-for [idx# 0 (< idx# n-elems#) (inc idx#)]
+                            (aset dst# (+ idx# dst-offset#)
+                                  (datatype->cast-fn
+                                   ~dst-dtype
+                                   (.get src# (+ idx# src-offset#)))))))]))
+        (into {}))
+   [:nio-buffer :nio-buffer]
+   (->> datatype-pairs
+        (map (fn [[src-dtype dst-dtype]]
+               [[src-dtype dst-dtype]
+                `(fn [src# src-offset# dst# dst-offset# n-elems#]
+                   (let [src# (datatype->buffer-cast-fn ~src-dtype src#)
+                         dst# (datatype->buffer-cast-fn ~dst-dtype dst#)
+                         src-offset# (long src-offset#)
+                         dst-offset# (long dst-offset#)
+                         n-elems# (long n-elems#)]
+                     (c-for [idx# 0 (< idx# n-elems#) (inc idx#)]
+                            (.put dst# (+ idx# dst-offset#)
+                                  (datatype->cast-fn
+                                   ~dst-dtype
+                                   (.get src# (+ idx# src-offset#)))))))]))
+        (into {}))})
 
 
-(defmacro buffer->array-copy-iter
-  [dest-type dest-type-fn copy-to-dest-fn dest-cast-fn src-cast-fn]
-  `[(keyword (name ~copy-to-dest-fn)) (create-buffer->array-fn ~src-cast-fn ~dest-type-fn ~dest-cast-fn)])
+(def copy-ops (build-core-copy-operations))
 
 
-(defmacro buffer->buffer-copy-iter
-  [dest-type dest-type-fn copy-to-dest-fn dest-cast-fn src-cast-fn]
-  `[(keyword (name ~copy-to-dest-fn)) (create-buffer->buffer-fn ~src-cast-fn ~dest-type-fn ~dest-cast-fn)])
+(doseq [[container-pair copy-map] copy-ops]
+  (add-copy-operation (first container-pair)
+                      (second container-pair)
+                      copy-map))
 
 
+(defn copy!
+  [src src-offset dst dst-offset n-elems]
+  (let [src-container (container-type src)
+        dst-container (container-type dst)
+        copy-fn-and-conversions
+        (if-let [table-copy-map (get @copy-table [src-container dst-container])]
+          [table-copy-map nil nil]
+          (let [src-conversions (get @conversion-table src-container)
+                dst-conversions (get @conversion-table dst-container)]
+            (->> (for [src-conversion (concat [[src-container nil]]
+                                              (seq src-conversions))
+                       dst-conversion (concat [[dst-container nil]]
+                                              (seq dst-conversions))]
+                   ;;When the copy table has an entry for the converted types
+                   ;;Then use the copy entry along with the conversion
+                   (let [[src-conv-cont src-conv] src-conversion
+                         [dst-conv-cont dst-conv] dst-conversion]
+                     (when-let [table-copy-map (get @copy-table [src-conv-cont dst-conv-cont])]
+                       [table-copy-map src-conv dst-conv])))
+                 (remove nil?)
+                 first)))]
 
-(defmacro array-marshal-impl
-  [ary-type cast-type-fn copy-to-fn cast-fn]
-  `(extend ~ary-type
-     PTypeToCopyToFn
-     {:get-copy-to-fn (fn [dest# offset#] #(~(eval copy-to-fn) %1 %2 dest# offset# %3))}
-     PCopyToArray
-     (->> (array-type-iterator array->array-copy-iter ~cast-type-fn)
-          (into {}))
-     PCopyToBuffer
-     (->> (buffer-type-iterator array->buffer-copy-iter ~cast-type-fn)
-          (into {}))))
-
-
-(defmacro buffer-marshal-impl
-  [buf-type cast-type-fn copy-to-fn cast-fn]
-  `(extend ~buf-type
-     PTypeToCopyToFn
-     {:get-copy-to-fn (fn [dest# offset#] #(~(eval copy-to-fn) %1 %2 dest# offset# %3))}
-     PCopyToArray
-     (->> (array-type-iterator buffer->array-copy-iter ~cast-type-fn)
-          (into {}))
-     PCopyToBuffer
-     (->> (buffer-type-iterator buffer->buffer-copy-iter ~cast-type-fn)
-          (into {}))))
-
-
-(def array-bindings
-  (array-type-iterator array-marshal-impl))
-
-
-(def buffer-bindings
-  (buffer-type-iterator buffer-marshal-impl))
-
-
-(defn as-byte-array-view
-  ^ByteArrayView [obj] obj)
-
-(defn as-short-array-view
-  ^ShortArrayView [obj] obj)
-
-(defn as-int-array-view
-  ^IntArrayView [obj] obj)
-
-(defn as-long-array-view
-  ^LongArrayView [obj] obj)
-
-(defn as-float-array-view
-  ^FloatArrayView [obj] obj)
-
-(defn as-double-array-view
-  ^DoubleArrayView [obj] obj)
+    (if-not copy-fn-and-conversions
+      ;;Use slow path if we don't have a good marshalling pathway
+      (base/generic-copy! src src-offset dst dst-offset n-elems)
+      ;;Else do a constant time conversion and do a fast path copy.
+      (let [[table-copy-map src-conv dst-conv] copy-fn-and-conversions
+            [src src-offset] (if src-conv
+                               (src-conv src src-offset)
+                               [src src-offset])
+            [dst dst-offset] (if dst-conv
+                               (dst-conv dst dst-offset)
+                               [dst dst-offset])
+            table-fn (get table-copy-map [(base/get-datatype src)
+                                          (base/get-datatype dst)])]
+        (table-fn src src-offset dst dst-offset n-elems)))))
 
 
-(defprotocol ArrayViewToArray
-  (view->array [view])
-  (view->array-offset [view offset]))
-
-
-(defmacro array-view-iterator
-  [inner-macro & args]
-  `[(~inner-macro ByteArrayView as-byte-array-view 'copy-to-byte-array byte ~@args)
-    (~inner-macro ShortArrayView as-short-array-view 'copy-to-short-array short ~@args)
-    (~inner-macro IntArrayView as-int-array-view 'copy-to-int-array int ~@args)
-    (~inner-macro LongArrayView as-long-array-view 'copy-to-long-array long ~@args)
-    (~inner-macro FloatArrayView as-float-array-view 'copy-to-float-array float ~@args)
-    (~inner-macro DoubleArrayView as-double-array-view 'copy-to-double-array double ~@args)])
-
-
-(defmacro view->copy-impl
-  [array-type cast-type-fn copy-to-fn cast-fn]
-  `[(keyword (name ~copy-to-fn)) (fn [src# src-offset# dest# dest-offset# n-elems#]
-                                   (~(eval copy-to-fn)
-                                    (view->array src#)
-                                    (view->array-offset src# src-offset#)
-                                    dest# dest-offset# n-elems#))])
-
-(defmacro array-view-marshal-impl
-  [view-type cast-type-fn copy-to-fn cast-fn]
-  `(extend ~view-type
-     ArrayViewToArray
-     {:view->array (fn [view#] (.data (~cast-type-fn view#)))
-      :view->array-offset (fn [view# offset#] (.index (~cast-type-fn view#) (long offset#)))}
-     PTypeToCopyToFn
-     {:get-copy-to-fn (fn [dest# offset#]
-                        #(~(eval copy-to-fn) %1 %2
-                          (view->array dest#)
-                          (view->array-offset dest# offset#) %3))}
-     PCopyToArray
-     (->> (array-type-iterator view->copy-impl)
-          (into {}))
-     PCopyToBuffer
-     (->> (buffer-type-iterator view->copy-impl)
-          (into {}))))
-
-
-(def array-view-bindings
-  (array-view-iterator array-view-marshal-impl))
-
-
-(defn marshal-copy-to
-  [src src-offset dest dest-offset n-elems]
-  ((get-copy-to-fn dest dest-offset) src src-offset n-elems))
+(extend-type Object
+  base/PCopyQuery
+  (get-copy-fn [dest dest-offset] #(copy! %1 %2 dest dest-offset %3)))


### PR DESCRIPTION
The previous conversion system used protocols do to do n^2 conversion lookup.  So for example you have arrays and nio buffers.  And 6 datatypes.  That gives you 36 datatype conversion routines across 2 containers which adds another multiple of 4.  So there are more than 100 conversion routines just with this.  Trying to come up with a protocol-base conversion mechanism to take care of a full marshalling system between these two container types and 6 datatypes ended up with something that was very confusing.

So, in addition to moving things into the tech namespace I moved the entire marshalling system into a set of maps that point to functions.  

There is a base copy table that is complete for all combinations of  arrays, nio buffers, and datatypes.

There is also a conversion table that is checked if the base copy table doesn't contain the container type pairs.  So views, or a c pointer type would have a conversion to an array or a nio buffer, respectively and then the original conversion functions would work fine.  This cuts down dramatically on the complexity of integrating new container types into the mix.  Given that I have found many times where a mis-implemented protocol cause the system to hit the slow path (1000 times slower) I think it is wise to attempt to design a system that is a simple as possible around this rather performance sensitive area.